### PR TITLE
Prevent crash when using non-existent locale

### DIFF
--- a/firetongue/FireTongue.hx
+++ b/firetongue/FireTongue.hx
@@ -949,6 +949,11 @@ package firetongue;
 		}
 		
 		private function logMissingFlag(id:String, flag:String):Void {
+			//Quick and dirty solution
+			if (_missing_flags == null) {
+				return;
+			}
+			
 			if (_missing_flags.exists(id) == false) {
 				_missing_flags.set(id, new Array<String>());
 			}


### PR DESCRIPTION
As the comment says, a quick and dirty temporary solution to the crashes in Android with non-existent locales.
