### PR TITLE
fix typos, plural logic proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ You can alse define custom locale notes (for i.e. tooltips) in index.xml:
 	<note id="official">
 		<!--This means that we solicited and paid the translator for an official translation-->
 		<text id="en-US,en-GB,en-CA,yo-DA" title="OFFICIAL" body="This is an official (paid) translation.$N$NContributors:"/>
-		<text id="nb-US" title="OFFISIELL" body="Dette er en offisiell (betalt) oversettelse.$N$NBidragsytere:"/>
+		<text id="nb-NOf" title="OFFISIELL" body="Dette er en offisiell (betalt) oversettelse.$N$NBidragsytere:"/>
 	</note>
 ```
 
@@ -456,7 +456,7 @@ Then at runtime you can call:
 
 ```haxe
 var oldfont = "verdana";
-var newfont = tongue.getFont(oldfont);  //returns "comicsans"
+var newfont = tongue.getFont(oldfont);  //returns "arial"
 
 var oldsize = 12;
 var newsize = tongue.getFontSize(oldsize); //returns 14


### PR DESCRIPTION
nice job, 

what with incomplete translations - fallback?

permutations don't scale well
option for 'simple' rules for plurals? IT'S VERY IMPORTANT and below is 'simple complex' example hard to implement this way

<PL> - special 'marker'/tag for PLural, if last on string, can be left not closed </PL>

// simple ranges
$FEW_MANY_PLURAL, one<PL,0>no<PL,2>two<PL,3>a few<PL,10>many</PL>    // default=1;  range 3-9 a few;  more than 9 - many

$CAT, cat<PL,0,2>cats </PL>  // default, no cats, >2 cats

// polish - more complex but ... quite simple ?
$CAT, kot<PL,0,5+>kotów<PL,2,22,23,24,?2,?3,?4>koty</PL>
// 2,3,4 koty; 5,6,7..11,12...21 kotów; 22,23,24.. koty; 25..101 kotów; 103 koty; [111,212... kotów] would be broken in this case; 222 koty;
// each number (>=2) OPENS RANGE (2-4) but followed by "+" (5+) defines DEFAULT FOR ALL GREATER, following rules with greater value are ONLY SINGLE VALUE axceptions (next "+"rule only changes greater_default)   - can be harder to implement (2 pases?)
// for start (if it looks to complex) it can be w/o ranges, only defaults and exceptions (order matters)
// these rules would be then:
$CAT, kot<PL,0,5+,?11,?12,?13,?14>kotów<PL,2,3,4,?2,?3,?4>koty</PL>   // ? means optional, any or no number
$CAT, kot<PL,0,5+,?11,?12,?13,?14>kotów<PL,?2,?3,?4>koty</PL>  // shorter, because ? matches 2,3,4, 22,23,24 except 11,12,..111,112 - order matters -- rules preinterpreted and stored as 'firewall chain'/array - first match return? f.e. 6 as falling in range_default rule gets value but not returns, trying next rules, if none matches returns this default; 12 matches 5+ range but flows into next rules .. ?12 SINGLE exception whitch returns immediately (not trying to apply next matching ?2 )
usage with OPTIONAL parameter for get()
count = 12;
plur_string = ft.get("$FEW_MANY_PLURAL",$count);
cat_string = ft.get("$CAT",$count);
// then use them with replace