### PR TITLE
Make firetongue work with NME

### DIFF
--- a/firetongue/Getter.hx
+++ b/firetongue/Getter.hx
@@ -40,12 +40,12 @@ class Getter
 	{
 		if (framework_ == null)
 		{
-			#if (openfl || openfl_legacy)
+			#if nme
+				framework = NME;
+			#elseif (openfl || openfl_legacy)
 				framework = OpenFL;
 			#elseif lime
 				framework = Lime;
-			#elseif nme
-				framework = NME;
 			#elseif sys
 				framework = VanillaSys;
 			#else
@@ -120,7 +120,7 @@ class Getter
 	
 	public function getDirectoryContents_OpenFL(path):Array<String>
 	{
-		#if (openfl || openfl_legacy)
+		#if (!nme && (openfl || openfl_legacy))
 			return limitPath(openfl.Assets.list(TEXT), path);
 		#else
 			return null;
@@ -179,7 +179,7 @@ class Getter
 	public function getDirectoryContents_NME(path):Array<String>
 	{
 		#if nme
-			return limitPath(nme.Assets.list(TEXT), path);
+			return limitPath([for (x in nme.Assets.list(TEXT)) x], path);
 		#else
 			return null;
 		#end


### PR DESCRIPTION
* nme is checked against before openfl as it also defines openfl
* nme.Assets.list requires an Array, not an Iterable
* guard against compile error in getDirectoryContents_OpenFL() under NME