### PR TITLE
Removed a unnecessary dependency to Flash's Sprite

### DIFF
--- a/firetongue/Replace.hx
+++ b/firetongue/Replace.hx
@@ -23,8 +23,6 @@
 
 package firetongue;
 
-import flash.display.Sprite;
-
 class Replace {
 
 	/**


### PR DESCRIPTION
Hi, here's an oneliner that could eventually help.
flash.display.Sprite wasn't used in this source file and could have blocked some targets from being available.

Have a nice day!