### PR TITLE
Fix haxe.xml.Fast deprecation warnigns with Haxe 4

### DIFF
--- a/firetongue/FireTongue.hx
+++ b/firetongue/FireTongue.hx
@@ -25,7 +25,12 @@ package firetongue;
 
 import firetongue.FireTongue.Case;
 import firetongue.FireTongue.LoadTask;
-import haxe.xml.Fast;
+
+#if haxe4
+	import haxe.xml.Access as Fast;
+#else
+	import haxe.xml.Fast;
+#end
 
 #if (sys)
 	import sys.FileSystem;


### PR DESCRIPTION
Compilation with Haxe 4 currently produces the following warning for each usage of `Fast`:

 >Warning : This typedef is deprecated in favor of haxe.xml.Access

This fix is the less invasive version where the old name (`Fast`) is kept. In Flixel libs, I did it the other way around and replaced usages with the "modern" `Access` naming (https://github.com/HaxeFlixel/flixel/commit/b6f954c7a30e8b58f2bf44b3f9fe6c8e1b3c0150). Not sure which one you prefer.