### PR TITLE
Std.is backwards compatibility

### DIFF
--- a/firetongue/format/CSV.hx
+++ b/firetongue/format/CSV.hx
@@ -23,6 +23,12 @@
 
 package firetongue.format;
 
+#if (haxe_ver >= 4.2)
+import Std.isOfType;
+#else
+import Std.is as isOfType;
+#end
+
 /**
  * A simple CSV (comma separated values) structure
  * @author Lars Doucet

--- a/firetongue/format/CSV.hx
+++ b/firetongue/format/CSV.hx
@@ -87,7 +87,7 @@ class CSV
 		if (thing == null)
 			return;
 
-		if (Std.isOfType(thing, Array))
+		if (isOfType(thing, Array))
 		{
 			clearArray(thing);
 		}


### PR DESCRIPTION
Checking the haxe version to use either `Std.is` or `Std.isOfType`. This prevents CI errors in haxeflixel when testing the
[RPGInterface demo](https://github.com/HaxeFlixel/flixel-demos/tree/dev/UserInterface/RPGInterface) in haxe versions older than 4.2